### PR TITLE
Fixed task executor to run on Windows platforms

### DIFF
--- a/tasks/_utils.js
+++ b/tasks/_utils.js
@@ -56,8 +56,13 @@ var spawn = require('child_process').spawn,
     exec(command, args, envVariables) {
 
       var path = require('path')
+      var os = require('os')
 
       return new Promise(function(resolve, reject) {
+
+        if (os.platform() == 'win32' || os.platform() == 'win64') {
+          command = command + '.cmd'
+        }
 
         // extend the env variables with some other custom options
         utils.extend(process.env, envVariables)

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -3,7 +3,7 @@ var utils = require('./_utils')
 module.exports = function(options) {
 
   options = utils.extend({
-    port: 6666
+    port: 3000
   }, options)
   // serve the contents of this folder
   return utils.exec('./node_modules/.bin/serve', utils.optionsToArray(options))

--- a/tasks/test/index.js
+++ b/tasks/test/index.js
@@ -8,7 +8,7 @@ module.exports = function(options) {
   }, options)
   // run karma
   return utils.exec(
-    './node_modules/karma/bin/karma',
+    './node_modules/.bin/karma',
     [
       'start',
       'tasks/test/karma.conf.js'


### PR DESCRIPTION
Should fix issue #8 Error when performing npm install on Windows 7.
This works on Windows 7. I have not tested this on linux.